### PR TITLE
Add to npm bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ You then want to create a `.enclaverc` file to inform enclave on some build sett
 $ touch .enclaverc
 ```
 
-Configure your enclaverc file:
+Configure your `.enclaverc` file:
 
-``` json
+```json
 /* .enclaverc */
 {
   "entry": "src/App.js",
@@ -59,9 +59,18 @@ Configure your enclaverc file:
 
 ```
 
-Once you're ready to compile your code, run this awkward command in your terminal:
+Add an `enclave` script to your `package.json`. 
+```json
+{
+  "scripts": {
+    "enclave": "enclave"
+  }
+}
 ```
-$ node node_modules/enclave/index.js
+
+Once you're ready to compile your code, run the script:
+```
+$ npm run enclave
 ```
 
 Then find your app at `http://localhost:3000`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "prestart": "webpack",
     "start": "webpack-dev-server"
   },
+  "bin": {
+    "enclave": "index.js"
+  },
   "author": "Ean Platter <eanplatter@gmail.com> (eanplatter.github.io)",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
This PR adds the `index.js` to the `node_modules/.bin` folder under the alias `enclave`.  This allows the `enclave` command to be run from npm scripts.

The `README.md` was also updated with new instructions.
