### PR TITLE
Fix NPM .bin link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var shell = require('shelljs')
 
 /**

--- a/src/postinstall/index.js
+++ b/src/postinstall/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 var shell = require('shelljs')
 var prompt = require('prompt')
 var prompts = require('./prompts')
@@ -36,7 +37,7 @@ function preventFinishFor(time) {
 var insertScript = {
   flag: '-i',
   insertionPoint: '"scripts": {',
-  addition: '\"scripts\": { \n    \"start\": \"node node_modules/enclave/src/index.js\",',
+  addition: '"scripts": {\n    "start": "enclave",',
   file: clientFiles.package
 }
 


### PR DESCRIPTION
This PR adds `#!/usr/env/bin node` to the index.js script so `enclave` works in npm scripts.
