### PR TITLE
linked contribution guide and fixed markdown header syntax + Improved Example + Added eslint dep 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,19 @@
-#Contributing to enclave
+# Contributing to enclave
 
 Enclave is a baby of a project right now, there is a lot of room for growth. If you're interested in contributing please do so!
 
-##Philosophy
+## Philosophy
 This project comes from a combination of two things, a complexity of configuring React applications with Webpack and Babel (especially for beginners), and my experience with compile-to-JavaScript languages, like Elm or CoffeeScript.
 
 I thought it would be nice to be able to write JSX and ES* the same way I wrote Elm. Just do it, and let some magic happen behind the scenes to make it browser compatible.
 
 Enclave was created with this approach in mind.
 
-We are essentially creating a balancing act between a robust tool and a simple API. We try to avoid adding friction to enclave's users. 
+We are essentially creating a balancing act between a robust tool and a simple API. We try to avoid adding friction to enclave's users.
 
 Frontend development is inundated with complex tools and frameworks. Complexity isn't necessarily a bad thing, and is often requisite in order to solve complex problems, but the more we can do with a simple API the better.
 
-##Code of conduct.
+## Code of conduct.
 Enclave as a tool is focused on reducing friction, and so is enclave's contributing. An open and frictionless environment of contributers is what we're aiming for. Be respectfut, don't say things you wouldn't say to someone's face.
 
 ## Sandbox App
@@ -23,12 +23,12 @@ To run the example app run `$ npm run example`.
 
 This is helpful if you're testing out webpack loaders or babel configurations.
 
-##Postinstall
+## Postinstall
 The `postinstall/` directory is where the prompts are generated for the user after they install enclave. You can currently test them out by just running `$ node postinstall/index.js`.
 
-##Tests
+## Tests
 Currently there are no tests, this is a problem. >.<
-  
+
 ## Pull Requests
 To make a PR, fork the repo, update it, and submit the PR.
 Make sure you do the following before making a PR:
@@ -46,5 +46,5 @@ Make sure you do the following before making a PR:
 * Write "attractive" code
 * Do not use the optional parameters of `setTimeout` and `setInterval`
 
-##Contact
+## Contact
 Reach ean on twitter @eanplatter or email eanplatter+enclave@gmail.com

--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@
   A simpler way to compile React applications.
 </p>
 
-##What is this?
+## What is this?
 An npm module which handles compiling your JSX and ES2015 code into browser-ready JavaScript.
 
-##Why do I want this?
+## Why do I want this?
 If you've ever had to make a React app from scratch, you know it can be rough to set up. Enclave removes the set up so you can focus on what's important, building your app.
 
-##Who is this for?
+## Who is this for?
 Primarily for those who don't want to go through the hassle of setting up a React project but who still want to flexibility that a starter kit can't provide.
 
-##Philosophy
+## Philosophy
 This project comes from a combination of two things, a complexity of configuring React applications with Webpack and Babel (especially for beginners), and my experience with compile-to-JavaScript languages, like Elm or CoffeeScript.
 
 I thought it would be nice to be able to write JSX and ES* the same way I wrote Elm. Just do it, and let some magic happen behind the scenes to make it browser compatible.
 
-Enclave was created with this approach in mind. 
+Enclave was created with this approach in mind.
 
 What I would like to do is eventually level enclave to the point where it maintains a sane API but is less reliant on Webpack, maybe even have it do the compiling as well.
 
@@ -28,14 +28,14 @@ All in all, this is open experimentation. Hopefully if you're wanting to get sta
 
 
 
-##Getting Started:
-###Short Version:
+## Getting Started:
+### Short Version:
 ```
 $ npm i enclave -S
 $ npm start
 ```
 
-###Long version
+### Long version
 ```
 $ mkdir my-new-app
 $ cd my-new-app
@@ -95,7 +95,7 @@ $ npm start
 Then find your app at `http://localhost:8080`
 > _If you set your port to something other than 8080, then go there instead!_.
 
-##Currently supported settings
+## Currently supported settings
 
 When enclave is installed in your project, it creates an `enclave.js` file. This is where your settings are stored. Currently supported settings are:
   - entry: {string} The relative path of your entry file, it tells Webpack where to start compiling. Ex. "src/App.js"
@@ -115,7 +115,6 @@ exports.index = "src/index.html"
 exports.live = true
 ```
 
-##Contributing
-If you're interested in contributing please make a PR. The code is pretty rocky right now, but I'd be stoked to see some participation. I've tried to document the code so that it's understandable. It's pretty small at the moment.
+## Contributing
 
-Just make a fork and a PR!
+[See the Contributing Guide](./CONTRIBUTING.md)

--- a/example/App.js
+++ b/example/App.js
@@ -1,19 +1,11 @@
 import React from 'react'
 import { render } from 'react-dom'
-import ENV from './env.json'
+import Example from './components/Example.jsx'
 
 class App extends React.Component {
   render() {
     return (
-      <div style={{textAlign: 'center'}}>
-        <img style={{maxWidth: '500px'}} src='http://bit.ly/1YEe536'/>
-        <h1>
-          Example
-        </h1>
-        <pre>
-          {JSON.stringify(ENV)}
-        </pre>
-      </div>
+      <Example />
     )
   }
 }

--- a/example/components/Example.jsx
+++ b/example/components/Example.jsx
@@ -1,0 +1,22 @@
+import React, { PropTypes } from 'react'
+import ENV from '../env.json'
+import '../styles/example.scss'
+
+class Example extends React.Component {
+  render () {
+    return (
+      <div className='example'>
+        <img src='http://bit.ly/1YEe536'/>
+        <h1>
+          Example
+        </h1>
+        <pre>
+          {JSON.stringify(ENV)}
+        </pre>
+        <p>SCSS and JSX Works Too</p>
+      </div>
+    )
+  }
+}
+
+export default Example

--- a/example/styles/example.scss
+++ b/example/styles/example.scss
@@ -1,0 +1,10 @@
+.example {
+  text-align: center;
+  font-family: Helvetica;
+  img {
+    max-width: 500px;
+  }
+  p {
+    color: slategrey;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-loader": "^5.3.2",
     "chalk": "^1.1.1",
     "css-loader": "^0.23.1",
+    "eslint": "^2.3.0",
     "history": "^1.13.0",
     "html-webpack-plugin": "^1.6.2",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
The package.json was missing the eslint dep even though it runs eslint on pre-commit so I fixed that. I added scss & JSX 'tests' in the example folder, and fixed docs.
