### PR TITLE
move presets to webpack

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-    "presets": ["es2015", "react"]
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enclave",
-  "version": "0.8.14",
+  "version": "0.8.15",
   "description": "An API for compiling React applications with Webpack",
   "main": "index.js",
   "repository": {

--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -26,9 +26,24 @@ module.exports = {
   },
   module: {
     loaders: [
-      {test: /\.js[x]?$/, exclude: /node_modules/, loader: 'react-hot!babel'},
-      {test: /\.json$/, exclude: /node_modules/, loader: 'json'},
-      {test: /\.[s]?css$/, exclude: /node_modules/, loader: 'style-loader!css-loader!sass-loader'}
+      {
+        test: /\.js[x]?$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['es2015', 'react']
+        }
+      },
+      {
+        test: /\.json$/,
+        exclude: /node_modules/,
+        loader: 'json'
+      },
+      {
+        test: /\.[s]?css$/,
+        exclude: /node_modules/,
+        loader: 'style-loader!css-loader!sass-loader'
+      }
     ]
   },
   plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,9 +55,24 @@ module.exports = {
   },
   module: {
     loaders: [
-      {test: /\.js[x]?$/, exclude: /node_modules/, loader: 'react-hot!babel'},
-      {test: /\.json$/, exclude: /node_modules/, loader: 'json'},
-      {test: /\.[s]?css$/, exclude: /node_modules/, loader: 'style-loader!css-loader!sass-loader'}
+      {
+        test: /\.js[x]?$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['es2015', 'react']
+        }
+      },
+      {
+        test: /\.json$/,
+        exclude: /node_modules/,
+        loader: 'json'
+      },
+      {
+        test: /\.[s]?css$/,
+        exclude: /node_modules/,
+        loader: 'style-loader!css-loader!sass-loader'
+      }
     ]
   },
   plugins: [HTMLWebpackPluginConfig, HotReloader],


### PR DESCRIPTION
Turns out if you have a .babelrc in enclave's root, webpack can't find it since it's technically running in the users app root. Just moved the presets directly to the webpack config file rather than generating a .babelrc file in the users root for now.
