### PR TITLE
remove redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "react": "^0.14.7",
     "react-dom": "^0.14.7",
     "react-hot-loader": "^1.3.0",
-    "react-redux": "^4.4.0",
-    "redux": "^3.3.1",
     "sass-loader": "^3.1.2",
     "shelljs": "^0.6.0",
     "style-loader": "^0.13.0",


### PR DESCRIPTION
Let's leave out extra deps for now. I'm not opposed to having different flavors of enclave that handle specific builds in the future, like enclave-redux maybe. But for now wanna keep it lean.
