### PR TITLE
Remove start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ All in all, this is open experimentation. Hopefully if you're wanting to get sta
 ### Short Version:
 ```
 $ npm i enclave -S
+```
+Add a script to your `package.json`:
+```json
+"scripts": {
+  "start": "enclave"
+}
+```
+Then run:
+```
 $ npm start
 ```
 
@@ -101,12 +110,16 @@ Configure your `index.html` file to have something with the id your react app is
 ```
 > _Also, this is where you would do things like hook in a cdn or google fonts or whatevs._
 
-Enclave will _automagically_ add a script to your `package.json` file which will allow you to run everything.
-To run it, type the following in your terminal:
+Enclave provides an npm script named `enclave` you can use in your `package.json` file:
+```json
+"scripts": {
+  "start": "enclave"
+}
+```
+Then to start your app:
 ```
 $ npm start
 ```
-> _If you want to edit your scripts, you can just move the start command somewhere else._
 
 Then find your app at `http://localhost:8080`
 > _If you set your port to something other than 8080, then go there instead!_.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ npm run enclave-eject
 
 The `enclave-eject` command transfers enclave's webpack configuration files to your app's root, and installs the dependencies you need in your app for you.
 
-After executing the eject command, `$ npm start` will compile and serve your code, just like before, sans enclave.
+After executing the eject command, `$ npm run serve` will compile and serve your code, just like before, sans enclave.
 
 
 ## Philosophy
@@ -48,16 +48,7 @@ All in all, this is open experimentation. Hopefully if you're wanting to get sta
 ### Short Version:
 ```
 $ npm i enclave -S
-```
-Add a script to your `package.json`:
-```json
-"scripts": {
-  "start": "enclave"
-}
-```
-Then run:
-```
-$ npm start
+$ npm run enclave-serve
 ```
 
 ### Long version
@@ -110,16 +101,12 @@ Configure your `index.html` file to have something with the id your react app is
 ```
 > _Also, this is where you would do things like hook in a cdn or google fonts or whatevs._
 
-Enclave provides an npm script named `enclave` you can use in your `package.json` file:
-```json
-"scripts": {
-  "start": "enclave"
-}
+Enclave will _automagically_ add a script to your `package.json` file which will allow you to run everything.
+To run it, type the following in your terminal:
 ```
-Then to start your app:
+$ npm run enclave-serve
 ```
-$ npm start
-```
+> _If you want to edit your scripts, you can just move the start command somewhere else._
 
 Then find your app at `http://localhost:8080`
 > _If you set your port to something other than 8080, then go there instead!_.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enclave",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "An API for compiling React applications with Webpack",
   "main": "index.js",
   "repository": {

--- a/src/eject/index.js
+++ b/src/eject/index.js
@@ -48,8 +48,8 @@ shell.sed(
  */
 var startScript = {
   flag: '-i',
-  searchRegex: '"start": "enclave",',
-  replacement: '"prestart": "webpack",\n    "start": "webpack-dev-server",',
+  searchRegex: '"enclave-serve": "enclave",',
+  replacement: '"prestart": "webpack",\n    "serve": "webpack-dev-server",',
   file: './package.json'
 }
 

--- a/src/postinstall/index.js
+++ b/src/postinstall/index.js
@@ -29,19 +29,6 @@ function preventFinishFor(time) {
   }, time)
 }
 
-
-/**
- * An object of strings used for inserting the start script into the user's package.json file with
- * the `shell.sed` command.
- * @type {{flag: string, insertionPoint: string, addition: string, file: string}}
- */
-var insertScript = {
-  flag: '-i',
-  insertionPoint: '"scripts": {',
-  addition: '"scripts": {\n    "start": "enclave",\n    "build": "node node_modules/enclave/src/build.js", \n    "enclave-eject": "node node_modules/enclave/src/eject/index.js",',
-  file: clientFiles.package
-}
-
 /**
  * This method is really ugly and implicit, I'm sorry.
  *
@@ -72,7 +59,6 @@ function configureConfigFile(err, result) {
   console.log(chalk.red('  index: ') + chalk.magenta(result.index))
   console.log(chalk.red('  live: ') + chalk.magenta(result.live))
   console.log(chalk.green('To run your app, just type'), chalk.green.bold('$ npm start'))
-  shell.sed(insertScript.flag, insertScript.insertionPoint, insertScript.addition, insertScript.file)
   preventFinishFor(5000)
 }
 

--- a/src/postinstall/index.js
+++ b/src/postinstall/index.js
@@ -29,6 +29,19 @@ function preventFinishFor(time) {
   }, time)
 }
 
+
+/**
+ * An object of strings used for inserting the start script into the user's package.json file with
+ * the `shell.sed` command.
+ * @type {{flag: string, insertionPoint: string, addition: string, file: string}}
+ */
+var insertScript = {
+  flag: '-i',
+  insertionPoint: '"scripts": {',
+  addition: '"scripts": {\n    "enclave-serve": "enclave",\n    "enclave-build": "node node_modules/enclave/src/build.js", \n    "enclave-eject": "node node_modules/enclave/src/eject/index.js",',
+  file: clientFiles.package
+}
+
 /**
  * This method is really ugly and implicit, I'm sorry.
  *
@@ -59,6 +72,7 @@ function configureConfigFile(err, result) {
   console.log(chalk.red('  index: ') + chalk.magenta(result.index))
   console.log(chalk.red('  live: ') + chalk.magenta(result.live))
   console.log(chalk.green('To run your app, just type'), chalk.green.bold('$ npm start'))
+  shell.sed(insertScript.flag, insertScript.insertionPoint, insertScript.addition, insertScript.file)
   preventFinishFor(5000)
 }
 


### PR DESCRIPTION
I wanted to discuss the proposal of removing the injected start script. 

I've seen some people using enclave in situations I never anticipated before, which makes me reconsider this injection.

For instance, a friend of mine was building a react component library, and he wanted to create a small react application inside his library to do some testing. 

So he made a directory and installed enclave, then pointed enclave to the directory. Worked like a charm, but since he was in an already existing app, it messed up his current npm start script.

Another version of this would be to inject a script, but under some kind of enclave prefix. That way if they already have an npm start script it wouldn't override it. Thoughts?
