### PR TITLE
update(requiredDependencies): remove react as required dep

### DIFF
--- a/src/eject/requiredDependencies.js
+++ b/src/eject/requiredDependencies.js
@@ -16,8 +16,6 @@ var requiredDependencies = [
   'json-loader',
   'node-sass',
   'raw-loader',
-  'react',
-  'react-dom',
   'react-hot-loader',
   'sass-loader',
   'style-loader',


### PR DESCRIPTION
These are now not a concern of enclave, they're already installed in the users `package.json` file, so no need to re-install them.
