### PR TITLE
Handle fallback with nested router paths

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ var HTMLWebpackPluginConfig = new HtmlWebpackPlugin({
 module.exports = {
   entry: entryArr,
   output: {
+    publicPath: '/',
     path: pathPrefix + settings.output,
     filename: 'index_bundle.js'
   },
@@ -94,7 +95,9 @@ module.exports = {
   devtool: 'cheap-module-eval-source-map',
   devServer: {
     contentBase: pathPrefix + settings.output,
-    historyApiFallback: true,
+    historyApiFallback: {
+      index: '/',
+    },
     hot: true,
   }
 }


### PR DESCRIPTION
Currently, the `historyApiFallback` config only handles fallback for a single path param.  Visiting `localhost:8080/foo/bar/` would fallback to `localhost:8080/foo/` and throw an error that it cannot find `localhost:8080/foo/index_bundle.js`.

This PR adds a more specific config that tells webpack dev server to fallback to the root path on 404s.  Allowing any JS router to catch and handle all routes, no matter their nesting.

See the relevant docs [here](https://webpack.github.io/docs/webpack-dev-server.html#the-historyapifallback-option).
