### PR TITLE
fix(webpack.build): add production env on prod build

### DIFF
--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -62,6 +62,9 @@ module.exports = {
     HTMLWebpackPluginConfig,
     UglifyJsPluginConfig,
     new webpack.optimize.DedupePlugin(),
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV) || '"production"',
+    }),
   ],
   devServer: {
     contentBase: pathPrefix + settings.output,


### PR DESCRIPTION
Fixes #107 

With React installed via NPM it defaults to dev mode, and doesn't switch to prod mode until you set the node_env to production. We were not doing that before, this PR fixes it.
